### PR TITLE
conf error fixed

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 recursive-include docs *
 recursive-include schedule/templates *
+recursive-include schedule/conf *
 recursive-include schedule/models/fixtures *.json
 recursive-include project_sample *


### PR DESCRIPTION
The conf folder was not present in the MANIFEST.in, which was causing an error trying to runserver in project_sample.I have fixed that my including the conf folder in MANIFEST.in

Please merge the pull request

Kabir Kukreti
