### PR TITLE
NoArgsCommand is deprecated, use BaseCommand instead.

### DIFF
--- a/schedule/management/commands/load_example_data.py
+++ b/schedule/management/commands/load_example_data.py
@@ -1,11 +1,11 @@
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 
 from django.core.management.color import no_style
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
     help = "Load some sample data into the db"
 
-    def handle_noargs(self, **options):
+    def handle(self, *args, **options):
         import datetime
         from schedule.models import Calendar
         from schedule.models import Event

--- a/schedule/management/commands/load_sample_data.py
+++ b/schedule/management/commands/load_sample_data.py
@@ -1,11 +1,11 @@
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 
 from django.core.management.color import no_style
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
     help = "Load some sample data into the db"
 
-    def handle_noargs(self, **options):
+    def handle(self, *args, **options):
         import datetime
         from schedule.models import Calendar
         from schedule.models import Event


### PR DESCRIPTION
The load_sample_data and load_example_data can't run on Django 1.10 because the NoArgsCommand was deprecated. Using BaseCommand and using the new handle function will fix it.